### PR TITLE
Fixed an issue with EnsureContainerAsync() failing due to trying to recreate existing parent

### DIFF
--- a/Aetheros.OneM2M.Api/Application.cs
+++ b/Aetheros.OneM2M.Api/Application.cs
@@ -188,11 +188,11 @@ namespace Aetheros.OneM2M.Api
 			}
 			Trace.WriteLine($"Did not find container '{name}'... ");
 
-			// If the primitive exists and is an AE, we do not need to recreate it. 
+			// If the primitive exists and is an AE, we do not need to recreate it.
 			var primAE = prim?.AE;
 			if (primAE != null)
 			{
-				// We don't need to return a container, we can just return null 
+				// We don't need to return a container, we can just return null
 				return null;
 			}
 

--- a/Aetheros.OneM2M.Api/Application.cs
+++ b/Aetheros.OneM2M.Api/Application.cs
@@ -160,7 +160,10 @@ namespace Aetheros.OneM2M.Api
 				return null;
 
 			Trace.WriteLine($"Looking for container '{name}'");
-			var container = (await TryGetPrimitiveAsync(name))?.Container;
+			var prim = await TryGetPrimitiveAsync(name);
+
+			// If the primitive exists and is a container, we try adding the AccessControlPolicy to it and/or return it
+			var container = prim?.Container;;
 			if (container != null)
 			{
 				if (aclUri != null)
@@ -182,6 +185,15 @@ namespace Aetheros.OneM2M.Api
 					}
 				}
 				return container;
+			}
+			Trace.WriteLine($"Did not find container '{name}'... ");
+
+			// If the primitive exists and is an AE, we do not need to recreate it. 
+			var primAE = prim?.AE;
+			if (primAE != null)
+			{
+				// We don't need to return a container, we can just return null 
+				return null;
 			}
 
 			string parentName = "";

--- a/Aetheros.OneM2M.Api/Application.cs
+++ b/Aetheros.OneM2M.Api/Application.cs
@@ -192,6 +192,7 @@ namespace Aetheros.OneM2M.Api
 			var primAE = prim?.AE;
 			if (primAE != null)
 			{
+				Trace.WriteLine($"Found AE '{name}'");
 				// We don't need to return a container, we can just return null
 				return null;
 			}


### PR DESCRIPTION
Fixed an issue where EnsureContainerAsync() would fail if a container was not found and the parent node was an AE. 

## Description of issue
### Original behavior
Consider the following OneM2M structure. 
```
PN_CSE (CSE)
\-> pr-demo-parent-ae (AE)
    \-> testContainer (Container - **does not exist yet**)
```
We wish to perform CRUD operations on a container called `testContainer` under `pr-demo-parent-ae` . The following interaction occurs when `EnsureContainerAsync()` is called on `testContainer`: 
1. `EnsureContainerAsync()` tries to get `/pr-demo-parent-ae/testContainer`. 
2. The container does not exist, so the server responds with `404 Not Found`. 
3. `EnsureContainerAsync()` attempts to find the parent node `/pr-demo-parent-ae`. 
4. `/pr-demo-parent-ae` exists, so the server responds with `200 OK`. 
5. `EnsureContainerAsync()` does not recognize that `/pr-demo-parent-ae` exists because it is an AE and not a container, and attempts to create a new container `pr-demo-parent-ae`. 
6. The server refuses to overwrite the AE and responds with `400 Bad Request`, which can cause `EnsureContainerAsync()` to crash.

This interaction is shown in log file [original.log](https://github.com/user-attachments/files/21304749/original.log). 

### Corrected Behavior 
With the same structure, the following interaction occurs: 
1. `EnsureContainerAsync()` tries to get `/pr-demo-parent-ae/testContainer`. 
2. The container does not exist, so the server responds with `404 Not Found`. 
3. `EnsureContainerAsync()` attempts to find the parent node `/pr-demo-parent-ae`. 
4. `/pr-demo-parent-ae` exists, so the server responds with `200 OK`. 
5. `EnsureContainerAsync()` recognizes that `/pr-demo-parent-ae` and does not create a new container for it. 
6. `EnsureContainerAsync()` creates a new container `/pr-demo-parent-ae/testContainer`. 

This is shown in log file [corrected.log](https://github.com/user-attachments/files/21304750/corrected.log).

## Changes made 

- [Aetheros.OneM2M.Api/Application.cs](https://github.com/aetheros/sdk-dotnet/commit/6ff399e82375a477fd815225222bb5f057598414#diff-b8ce2e6567b683a4646d2ed968cefdbc63884b293031c52137e2c5aa70cb6131)
Added a check to `EnsureContainerAsync()` after looking for the containers and before creating the parent containers to check if the parent node is an AE. If the parent is an AE, `null` is returned which prevents the creation of a container which conflicts with the parent. 

## Testing method used

I tested this patch with a modified version of a program I am contractually obligated to protect. Please contact me if you have questions. 



